### PR TITLE
Allow specifying a custom instance ID for USB licensing dongles

### DIFF
--- a/driver/vhci/vhci_dev.h
+++ b/driver/vhci/vhci_dev.h
@@ -106,6 +106,9 @@ typedef struct
 	// unique port number of the device on the bus
 	ULONG	port;
 
+	// Instance ID or Serial Number
+	ULONGLONG	instance;
+
 	// Link point to hold all the vpdos for a single bus together
 	LIST_ENTRY	Link;
 

--- a/driver/vhci/vhci_plugin.c
+++ b/driver/vhci/vhci_plugin.c
@@ -77,6 +77,7 @@ vhci_plugin_dev(ioctl_usbip_vhci_plugin *plugin, pusbip_vhub_dev_t vhub, PFILE_O
 	vpdo->subclass = plugin->subclass;
 	vpdo->protocol = plugin->protocol;
 	vpdo->inum = plugin->inum;
+	vpdo->instance = plugin->instance;
 
 	devpdo_old = (pusbip_vpdo_dev_t)InterlockedCompareExchangePointer(&(fo->FsContext), vpdo, 0);
 	if (devpdo_old) {

--- a/driver/vhci/vhci_vpdo.c
+++ b/driver/vhci/vhci_vpdo.c
@@ -190,7 +190,7 @@ vhci_QueryDeviceCaps_vpdo(pusbip_vpdo_dev_t vpdo, PIRP Irp)
 	deviceCapabilities->SurpriseRemovalOK = TRUE;
 
 	// We don't support system-wide unique IDs.
-	deviceCapabilities->UniqueID = FALSE;
+	deviceCapabilities->UniqueID = TRUE;
 
 	// Specify whether the Device Manager should suppress all
 	// installation pop-ups except required pop-ups such as
@@ -231,11 +231,11 @@ setup_vpdo_inst_id(pusbip_vpdo_dev_t vpdo, PIRP irp)
 {
 	PWCHAR	id_inst;
 
-	id_inst = ExAllocatePoolWithTag(PagedPool, 5 * sizeof(wchar_t), USBIP_VHCI_POOL_TAG);
+	id_inst = ExAllocatePoolWithTag(PagedPool, 17 * sizeof(wchar_t), USBIP_VHCI_POOL_TAG);
 	if (id_inst == NULL) {
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
-	RtlStringCchPrintfW(id_inst, 5, L"%04hx", vpdo->port);
+	RtlStringCchPrintfW(id_inst, 17, L"%llx", vpdo->instance);
 	irp->IoStatus.Information = (ULONG_PTR)id_inst;
 	return STATUS_SUCCESS;
 }

--- a/driver/vhci/vhci_vpdo.c
+++ b/driver/vhci/vhci_vpdo.c
@@ -235,7 +235,7 @@ setup_vpdo_inst_id(pusbip_vpdo_dev_t vpdo, PIRP irp)
 	if (id_inst == NULL) {
 		return STATUS_INSUFFICIENT_RESOURCES;
 	}
-	RtlStringCchPrintfW(id_inst, 17, L"%llx", vpdo->instance);
+	RtlStringCchPrintfW(id_inst, 17, L"%016llx", vpdo->instance);
 	irp->IoStatus.Information = (ULONG_PTR)id_inst;
 	return STATUS_SUCCESS;
 }

--- a/include/usbip_vhci_api.h
+++ b/include/usbip_vhci_api.h
@@ -71,6 +71,8 @@ typedef struct _ioctl_usbip_vhci_plugin
 	unsigned char	protocol;
 
 	signed char	port;
+
+	unsigned long long	instance;
 } ioctl_usbip_vhci_plugin;
 
 typedef struct _ioctl_usbip_vhci_get_ports_status

--- a/userspace/lib/usbip_util.c
+++ b/userspace/lib/usbip_util.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
+#include <time.h>
 
 wchar_t *
 utf8_to_wchar(const char *str)
@@ -84,4 +85,17 @@ get_module_dir(void)
 			return path_mod;
 		}
 	}
+}
+
+// Courtesy of https://stackoverflow.com/a/28116032
+unsigned long long
+llrand() {
+	unsigned long long r = 0;
+
+	srand((unsigned int)time(NULL));
+	for (int i = 0; i < 5; ++i) {
+		r = (r << 15) | (rand() & 0x7FFF);
+	}
+
+	return r & 0xFFFFFFFFFFFFFFFFULL;
 }

--- a/userspace/lib/usbip_util.h
+++ b/userspace/lib/usbip_util.h
@@ -5,3 +5,4 @@ wchar_t *utf8_to_wchar(const char *str);
 int vasprintf(char **strp, const char *fmt, va_list ap);
 int asprintf(char **strp, const char *fmt, ...);
 char *get_module_dir(void);
+unsigned long long llrand(void);

--- a/userspace/src/usbip/usbip_vhci.c
+++ b/userspace/src/usbip/usbip_vhci.c
@@ -121,6 +121,8 @@ usbip_vhci_attach_device(HANDLE hdev, int port, usbip_wudev_t *wudev)
 
 	plugin.port = port;
 
+	plugin.instance = wudev->idInstance;
+
 	if (!DeviceIoControl(hdev, IOCTL_USBIP_VHCI_PLUGIN_HARDWARE,
 		&plugin, sizeof(plugin), NULL, 0, &unused, NULL)) {
 		err("usbip_vhci_attach_device: DeviceIoControl failed: err: 0x%lx", GetLastError());

--- a/userspace/src/usbip/usbip_wudev.c
+++ b/userspace/src/usbip/usbip_wudev.c
@@ -97,6 +97,8 @@ setup_wudev_from_udev(usbip_wudev_t *wudev, struct usbip_usb_device *udev)
 	wudev->bDeviceProtocol = udev->bDeviceProtocol;
 
 	wudev->bNumInterfaces = udev->bNumInterfaces;
+
+	wudev->idInstance;
 }
 
 void

--- a/userspace/src/usbip/usbip_wudev.h
+++ b/userspace/src/usbip/usbip_wudev.h
@@ -17,6 +17,8 @@ typedef struct {
 	uint8_t		bDeviceProtocol;
 
 	uint8_t		bNumInterfaces;
+
+	uint64_t	idInstance;
 } usbip_wudev_t;
 
 extern void get_wudev(SOCKET sockfd, usbip_wudev_t *uwdev, struct usbip_usb_device *udev);


### PR DESCRIPTION
Some software products which rely on USB licensing dongles verify that the device serial number matches the license key. A common scheme is a standard mass storage device containing a license file keyed to the storage device's vendor, product, and serial to prevent duplication. The full device instance path is commonly used as the string for comparison, with the final portion (instance ID) representing the serial number.

USBIP currently brings over the vendor and product, but not the serial number, so these licensing checks fail. This pull request adds in support to supply a custom instance ID when attaching a device.

The instance ID can be supplied to the attach command as an (up to) 16-character hexadecimal value using the optional -i parameter. If supplied, the full instance ID is used. If omitted, a random instance ID is automatically generated and used.