### PR TITLE
Remove pending urbr's of a vhci aborted pipe

### DIFF
--- a/driver/vhci/usbreq.c
+++ b/driver/vhci/usbreq.c
@@ -172,6 +172,38 @@ free_urbr(struct urb_req *urbr)
 	ExFreeToNPagedLookasideList(&g_lookaside, urbr);
 }
 
+BOOLEAN
+is_port_urbr(struct urb_req *urbr, unsigned char epaddr)
+{
+	PIRP	irp = urbr->irp;
+	PURB	urb;
+	PIO_STACK_LOCATION	irpstack;
+	USBD_PIPE_HANDLE	hPipe;
+
+	if (irp == NULL)
+		return FALSE;
+
+	irpstack = IoGetCurrentIrpStackLocation(irp);
+	urb = irpstack->Parameters.Others.Argument1;
+	if (urb == NULL)
+		return FALSE;
+
+	switch (urb->UrbHeader.Function) {
+	case URB_FUNCTION_BULK_OR_INTERRUPT_TRANSFER:
+		hPipe = urb->UrbBulkOrInterruptTransfer.PipeHandle;
+		break;
+	case URB_FUNCTION_ISOCH_TRANSFER:
+		hPipe = urb->UrbIsochronousTransfer.PipeHandle;
+		break;
+	default:
+		return FALSE;
+	}
+
+	if (PIPE2ADDR(hPipe) == epaddr)
+		return TRUE;
+	return FALSE;
+}
+
 NTSTATUS
 submit_urbr(pusbip_vpdo_dev_t vpdo, struct urb_req *urbr)
 {

--- a/driver/vhci/usbreq.h
+++ b/driver/vhci/usbreq.h
@@ -31,5 +31,9 @@ submit_urbr(pusbip_vpdo_dev_t vpdo, struct urb_req *urbr);
 
 extern struct urb_req *
 create_urbr(pusbip_vpdo_dev_t vpdo, PIRP irp, unsigned long seq_num_unlink);
+
 extern void
 free_urbr(struct urb_req *urbr);
+
+extern BOOLEAN
+is_port_urbr(struct urb_req *urbr, unsigned char epaddr);

--- a/driver/vhci/vhci_ioctl.c
+++ b/driver/vhci/vhci_ioctl.c
@@ -14,14 +14,48 @@ vhci_get_ports_status(ioctl_usbip_vhci_get_ports_status *st, pusbip_vhub_dev_t v
 extern PAGEABLE NTSTATUS
 vhci_eject_device(PUSBIP_VHCI_EJECT_HARDWARE Eject, pusbip_vhub_dev_t vhub);
 
-static NTSTATUS
-process_urb_abort_pipe(pusbip_vpdo_dev_t vpdo, PURB urb)
+NTSTATUS
+vhci_ioctl_abort_pipe(pusbip_vpdo_dev_t vpdo, USBD_PIPE_HANDLE hPipe)
 {
-	UNREFERENCED_PARAMETER(vpdo);
-	UNREFERENCED_PARAMETER(urb);
+	KIRQL		oldirql;
+	PLIST_ENTRY	le;
+	unsigned char	epaddr;
 
-	////TODO need to check
-	DBGI(DBG_IOCTL, "abort_pipe: %x\n", urb->UrbPipeRequest.PipeHandle);
+	if (!hPipe) {
+		DBGI(DBG_IOCTL, "vhci_ioctl_abort_pipe: empty pipe handle\n");
+		return STATUS_INVALID_PARAMETER;
+	}
+
+	epaddr = PIPE2ADDR(hPipe);
+
+	DBGI(DBG_IOCTL, "vhci_ioctl_abort_pipe: EP: %02x\n", epaddr);
+
+	KeAcquireSpinLock(&vpdo->lock_urbr, &oldirql);
+
+	// remove all URBRs of the aborted pipe
+	for (le = vpdo->head_urbr.Flink; le != &vpdo->head_urbr;) {
+		struct urb_req	*urbr_local = CONTAINING_RECORD(le, struct urb_req, list_all);
+		le = le->Flink;
+
+		if (!is_port_urbr(urbr_local, epaddr))
+			continue;
+
+		DBGI(DBG_IOCTL, "aborted urbr removed: %s\n", dbg_urbr(urbr_local));
+
+		if (urbr_local->irp) {
+			PIRP	irp = urbr_local->irp;
+
+			IoSetCancelRoutine(irp, NULL);
+			irp->IoStatus.Status = STATUS_CANCELLED;
+			IoCompleteRequest(irp, IO_NO_INCREMENT);
+		}
+		RemoveEntryListInit(&urbr_local->list_state);
+		RemoveEntryListInit(&urbr_local->list_all);
+		free_urbr(urbr_local);
+	}
+
+	KeReleaseSpinLock(&vpdo->lock_urbr, oldirql);
+
 	return STATUS_SUCCESS;
 }
 
@@ -62,7 +96,7 @@ process_irp_urb_req(pusbip_vpdo_dev_t vpdo, PIRP irp, PURB urb)
 
 	switch (urb->UrbHeader.Function) {
 	case URB_FUNCTION_ABORT_PIPE:
-		return process_urb_abort_pipe(vpdo, urb);
+		return vhci_ioctl_abort_pipe(vpdo, urb->UrbPipeRequest.PipeHandle);
 	case URB_FUNCTION_GET_CURRENT_FRAME_NUMBER:
 		return process_urb_get_frame(vpdo, urb);
 	case URB_FUNCTION_SELECT_CONFIGURATION:

--- a/driver/vhci/vhci_read.c
+++ b/driver/vhci/vhci_read.c
@@ -87,26 +87,25 @@ store_urb_reset_pipe(PIRP irp, PURB urb, struct urb_req *urbr)
 	 */
 	struct _URB_PIPE_REQUEST	*urb_rp = &urb->UrbPipeRequest;
 	struct usbip_header	*hdr;
-	int	in, type;
+	int	type;
 
 	hdr = get_usbip_hdr_from_read_irp(irp);
 	if (hdr == NULL) {
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
-	in = PIPE2DIRECT(urb_rp->PipeHandle);
 	type = PIPE2TYPE(urb_rp->PipeHandle);
 	if (type != USB_ENDPOINT_TYPE_BULK && type != USB_ENDPOINT_TYPE_INTERRUPT) {
 		DBGW(DBG_READ, "CLEAR not allowed to a non-bulk pipe[%d]\n", type);
 		return STATUS_INVALID_PARAMETER;
 	}
 
-	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, in, 0, 0, 0);
+	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, 0, 0, 0, 0);
 	RtlZeroMemory(hdr->u.cmd_submit.setup, 8);
 
 	usb_cspkt_t *csp = (usb_cspkt_t *)hdr->u.cmd_submit.setup;
 	build_setup_packet(csp, 0, BMREQUEST_STANDARD, BMREQUEST_TO_ENDPOINT, USB_REQUEST_CLEAR_FEATURE);
-	csp->wIndex.LowByte = PIPE2ADDR(urb_rp->PipeHandle) | (unsigned char)(in << 7); // Specify enpoint address and direction
+	csp->wIndex.LowByte = PIPE2DIRECT(urb_rp->PipeHandle) | PIPE2ADDR(urb_rp->PipeHandle);
 	csp->wIndex.HiByte = 0;
 	csp->wValue.W = 0; // clear ENDPOINT_HALT
 	csp->wLength = 0;

--- a/driver/vhci/vhci_read.c
+++ b/driver/vhci/vhci_read.c
@@ -87,13 +87,14 @@ store_urb_reset_pipe(PIRP irp, PURB urb, struct urb_req *urbr)
 	 */
 	struct _URB_PIPE_REQUEST	*urb_rp = &urb->UrbPipeRequest;
 	struct usbip_header	*hdr;
-	int	type;
+	int	in, type;
 
 	hdr = get_usbip_hdr_from_read_irp(irp);
 	if (hdr == NULL) {
 		return STATUS_BUFFER_TOO_SMALL;
 	}
 
+	in = PIPE2DIRECT(urb_rp->PipeHandle);
 	type = PIPE2TYPE(urb_rp->PipeHandle);
 	if (type != USB_ENDPOINT_TYPE_BULK && type != USB_ENDPOINT_TYPE_INTERRUPT) {
 		DBGW(DBG_READ, "CLEAR not allowed to a non-bulk pipe[%d]\n", type);
@@ -105,7 +106,7 @@ store_urb_reset_pipe(PIRP irp, PURB urb, struct urb_req *urbr)
 
 	usb_cspkt_t *csp = (usb_cspkt_t *)hdr->u.cmd_submit.setup;
 	build_setup_packet(csp, 0, BMREQUEST_STANDARD, BMREQUEST_TO_ENDPOINT, USB_REQUEST_CLEAR_FEATURE);
-	csp->wIndex.LowByte = PIPE2DIRECT(urb_rp->PipeHandle) | PIPE2ADDR(urb_rp->PipeHandle);
+	csp->wIndex.LowByte = PIPE2ADDR(urb_rp->PipeHandle) | (unsigned char)(in << 7); // Specify enpoint address and direction
 	csp->wIndex.HiByte = 0;
 	csp->wValue.W = 0; // clear ENDPOINT_HALT
 	csp->wLength = 0;

--- a/driver/vhci/vhci_read.c
+++ b/driver/vhci/vhci_read.c
@@ -101,12 +101,13 @@ store_urb_reset_pipe(PIRP irp, PURB urb, struct urb_req *urbr)
 		return STATUS_INVALID_PARAMETER;
 	}
 
-	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, in, urb_rp->PipeHandle, 0, 0);
+	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, in, 0, 0, 0);
 	RtlZeroMemory(hdr->u.cmd_submit.setup, 8);
 
 	usb_cspkt_t *csp = (usb_cspkt_t *)hdr->u.cmd_submit.setup;
 	build_setup_packet(csp, 0, BMREQUEST_STANDARD, BMREQUEST_TO_ENDPOINT, USB_REQUEST_CLEAR_FEATURE);
-	csp->wIndex.W = PIPE2ADDR(urb_rp->PipeHandle); // specify endpoint number
+	csp->wIndex.LowByte = PIPE2ADDR(urb_rp->PipeHandle) | (unsigned char)(in << 7); // Specify enpoint address and direction
+	csp->wIndex.HiByte = 0;
 	csp->wValue.W = 0; // clear ENDPOINT_HALT
 	csp->wLength = 0;
 


### PR DESCRIPTION
This pull request is created to discuss several issues from #90.

- IRP cancellation and urbr removal for an aborted pipe. Are they required?
- Verifying a resetting pipe routine(store_urb_reset_pipe)