### PR TITLE
Abort pipe - bugfix in setup packet

### DIFF
--- a/driver/vhci/vhci_read.c
+++ b/driver/vhci/vhci_read.c
@@ -101,12 +101,13 @@ store_urb_reset_pipe(PIRP irp, PURB urb, struct urb_req *urbr)
 		return STATUS_INVALID_PARAMETER;
 	}
 
-	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, in, urb_rp->PipeHandle, 0, 0);
+	set_cmd_submit_usbip_header(hdr, urbr->seq_num, urbr->vpdo->devid, 0, 0, 0, 0);
 	RtlZeroMemory(hdr->u.cmd_submit.setup, 8);
 
 	usb_cspkt_t *csp = (usb_cspkt_t *)hdr->u.cmd_submit.setup;
 	build_setup_packet(csp, 0, BMREQUEST_STANDARD, BMREQUEST_TO_ENDPOINT, USB_REQUEST_CLEAR_FEATURE);
-	csp->wIndex.W = PIPE2ADDR(urb_rp->PipeHandle); // specify endpoint number
+	csp->wIndex.LowByte = PIPE2ADDR(urb_rp->PipeHandle) | (unsigned char)(in << 7); // Specify enpoint address and direction
+	csp->wIndex.HiByte = 0;
 	csp->wValue.W = 0; // clear ENDPOINT_HALT
 	csp->wLength = 0;
 


### PR DESCRIPTION
Currently the CLEAR_FEATURE(CLEAR_STALL) has not specified direction
which leads to protocol error on usbip server.
CLEAR_FEATURE must be sent to default control pipe!