### PR TITLE
usbip install fails to remove root device, add cleanup in case of failure

### DIFF
--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -268,6 +268,12 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 		INSTALLFLAG_FORCE,
 		FALSE);
 	if (!result_ok) {
+		last_error = GetLastError();
+		err("inf file install failed %u", last_error);
+		if (last_error == ERROR_NO_CATALOG_FOR_OEM_INF)
+		{
+			err("ERROR_NO_CATALOG_FOR_OEM_INF might be caused by not installed Driver Certificates");
+		}
 		goto error;
 	}
 

--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -138,31 +138,28 @@ static BOOL usbip_install_remove_device(const struct usbip_install_devinfo_struc
 	}
 
 	// from now on use goto error so that we wont leak devinfoset
-
-	const BOOL open_ok = SetupDiOpenDeviceInfo(devinfoset,
+	BOOL result_ok = result_ok = SetupDiOpenDeviceInfo(devinfoset,
 		dev_data->dev_instance_path,
 		GetConsoleWindow(),
 		0,
 		&devinfo_data);
-	if (!open_ok) {
+	if (!result_ok) {
 		err("Cannot open DeviceInfo, code %u", GetLastError());
 		goto error;
 	}
-	const BOOL uninstall_ok = DiUninstallDevice(GetConsoleWindow(),
+
+	result_ok = DiUninstallDevice(GetConsoleWindow(),
 		devinfoset,
 		&devinfo_data,
 		0, FALSE);
-	if (!uninstall_ok) {
+	if (!result_ok) {
 		err("Cannot uninstall existing device!");
 		goto error;
 	}
 
-	SetupDiDestroyDeviceInfoList(devinfoset);
-	return TRUE;
-
 error:
 	SetupDiDestroyDeviceInfoList(devinfoset);
-	return FALSE;
+	return result_ok;
 }
 
 static int usbip_install_base(struct usbip_install_devinfo_struct *data)

--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -272,7 +272,7 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 		err("inf file install failed %u", last_error);
 		if (last_error == ERROR_NO_CATALOG_FOR_OEM_INF)
 		{
-			err("ERROR_NO_CATALOG_FOR_OEM_INF might be caused by not installed Driver Certificates");
+			err("Missing .cat file");
 		}
 		goto error;
 	}

--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -269,9 +269,8 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 		FALSE);
 	if (!result_ok) {
 		last_error = GetLastError();
-		err("inf file install failed %u", last_error);
-		if (last_error == ERROR_NO_CATALOG_FOR_OEM_INF)
-		{
+		err("%s: UpdateDriverForPlugAndPlayDevices failed: status: %x", __FUNCTION__, last_error);
+		if (last_error == ERROR_NO_CATALOG_FOR_OEM_INF) {
 			err("Missing .cat file");
 		}
 		goto error;

--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -126,6 +126,7 @@ static BOOL usbip_install_get_hardware_id(char *buffer, DWORD buffer_size,
 static BOOL usbip_install_remove_device(const struct usbip_install_devinfo_struct *dev_data)
 {
 	assert(dev_data != NULL);
+	info("Removing previous instance of %s", dev_data->dev_instance_path);
 
 	HDEVINFO devinfoset = { 0 };
 	SP_DEVINFO_DATA devinfo_data = { 0 };

--- a/userspace/src/usbip/usbip_install.c
+++ b/userspace/src/usbip/usbip_install.c
@@ -126,7 +126,7 @@ static BOOL usbip_install_get_hardware_id(char *buffer, DWORD buffer_size,
 static BOOL usbip_install_remove_device(const struct usbip_install_devinfo_struct *dev_data)
 {
 	assert(dev_data != NULL);
-	info("Removing previous instance of %s", dev_data->dev_instance_path);
+	info("removing instance of %s", dev_data->dev_instance_path);
 
 	HDEVINFO devinfoset = { 0 };
 	SP_DEVINFO_DATA devinfo_data = { 0 };
@@ -172,6 +172,7 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 	char inf_file[BUFFER_SIZE] = { 0 };
 	char hw_id[BUFFER_SIZE] = { 0 };
 	char dev_decription[BUFFER_SIZE] = { 0 };
+	BOOL device_created = FALSE;
 
 	HDEVINFO devinfoset = { 0 };
 	SP_DEVINFO_DATA devinfo_data = { 0 };
@@ -237,6 +238,7 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 		break;
 	} while (TRUE);
 
+	device_created = TRUE;
 	result_ok = usbip_install_get_hardware_id(hw_id, BUFFER_SIZE - 1,
 		inf_handle, data);
 	if (!result_ok) {
@@ -276,6 +278,14 @@ static int usbip_install_base(struct usbip_install_devinfo_struct *data)
 error:
 	err("Cannot install usbip_vhci driver");
 	SetupDiDestroyDeviceInfoList(devinfoset);
+
+	if (device_created) {
+		result_ok = usbip_install_remove_device(data);
+		if (!result_ok) {
+			err("Cannot get DeviceInfo. Remove device manually by Device Manager, restart PC and try again");
+		}
+	}
+
 	return 1;
 }
 


### PR DESCRIPTION
Description:
This fixes inability of `usbip install` to remove USB-IP root device, also adds cleanup in case of fail to install

Steps to reproduce:
1. Forget to install certificates / dont setup test certificate in project
2. Build solution
2. Open powershell, goto output dir
3. Run `usbip.exe install`

Result:
Installation fails due to invalid signing of sys and leaves created USB-IP root device
Subsequent `usbip.exe install` fails with removing root device telling user to manually delete it

