### PR TITLE
set default test signing certificate to usbip_test.pfx

### DIFF
--- a/driver/stub/usbip_stub.vcxproj
+++ b/driver/stub/usbip_stub.vcxproj
@@ -92,6 +92,9 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
+  <PropertyGroup>
+    <TestCertificate>$(ProjectDir)..\usbip_test.pfx</TestCertificate>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>

--- a/driver/vhci/usbip_vhci.vcxproj
+++ b/driver/vhci/usbip_vhci.vcxproj
@@ -94,6 +94,9 @@
     <DriverTargetPlatform>Desktop</DriverTargetPlatform>
     <SpectreMitigation>false</SpectreMitigation>
   </PropertyGroup>
+  <PropertyGroup>
+    <TestCertificate>$(ProjectDir)..\usbip_test.pfx</TestCertificate>
+  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>


### PR DESCRIPTION
By default usbip_test.pfx is not set and user has to do it, this change uses usbip_test.pfx by default, making it more fool-proof :)