### PR TITLE
usbip attach - pressing ctrl-c can result in a hang

### DIFF
--- a/driver/vhci/vhci_read.c
+++ b/driver/vhci/vhci_read.c
@@ -737,6 +737,33 @@ store_urbr(PIRP irp, struct urb_req *urbr)
 	return status;
 }
 
+static VOID
+on_pending_irp_read_cancelled(PDEVICE_OBJECT devobj, PIRP irp_read)
+{
+	DBGI(DBG_READ, "pending irp read cancelled");
+
+	KIRQL	oldirql;
+	PIO_STACK_LOCATION	irpstack;
+	pusbip_vpdo_dev_t	vpdo;
+
+	vpdo = (pusbip_vpdo_dev_t)devobj->DeviceExtension;
+
+	KeAcquireSpinLock(&vpdo->lock_urbr, &oldirql);
+	if (vpdo->pending_read_irp == irp_read) {
+		vpdo->pending_read_irp = NULL;
+		KeReleaseSpinLock(&vpdo->lock_urbr, oldirql);
+		IoReleaseCancelSpinLock(irp_read->CancelIrql);
+
+		irp_read->IoStatus.Status = STATUS_CANCELLED;
+		IoCompleteRequest(irp_read, IO_NO_INCREMENT);
+	}
+	else {
+		KeReleaseSpinLock(&vpdo->lock_urbr, oldirql);
+		IoReleaseCancelSpinLock(irp_read->CancelIrql);
+		DBGI(DBG_READ, "cancelled IRP already handled in other thread");
+	}
+}
+
 static NTSTATUS
 process_read_irp(pusbip_vpdo_dev_t vpdo, PIRP read_irp)
 {
@@ -763,6 +790,7 @@ process_read_irp(pusbip_vpdo_dev_t vpdo, PIRP read_irp)
 	else {
 		urbr = find_pending_urbr(vpdo);
 		if (urbr == NULL) {
+			IoSetCancelRoutine(read_irp, on_pending_irp_read_cancelled);
 			IoMarkIrpPending(read_irp);
 			vpdo->pending_read_irp = read_irp;
 			KeReleaseSpinLock(&vpdo->lock_urbr, oldirql);


### PR DESCRIPTION
Description:
When doing ctrl-c to stop `usbip attach` - usbip would hang

Reproduction rate:
~25%

Steps to reproduce:
1. Install client driver
2. Have a linux server, bind a device, eg mouse
3. `usbip attach -r <ip> -b <device>`
4. ctrl-c

Result:
usbip would hang

Root-cause:
Debugging showed that the usbip hanged on `buff_src.in_reading` cleanup - doing IoCancel in a loop, which did nothing - everytime this happened there was also `buff_dst.in_reading` also set

Further debug in usb_vhci showed that the irp was marked as pending and stored in `vpdo->pending_read_irp` with no chance to get cancelled.


I've reused similiar pattern as in stub_res.c


