### PR TITLE
debug print levels fix

### DIFF
--- a/driver/lib/dbgcommon.h
+++ b/driver/lib/dbgcommon.h
@@ -3,15 +3,15 @@
 #include <ntddk.h>
 
 /* DPFLTR_SYSTEM_ID emits too many unrelated kernel logs */
-#define MY_DFPLTR	DPFLTR_IHVDRIVER_ID
+#define MY_DPFLTR	DPFLTR_IHVDRIVER_ID
 
 #ifdef DBG
 
 #include "usbip_proto.h"
 
-#define DBGE(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
-#define DBGW(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_WARNING_LEVEL, DRVPREFIX ":(WW) " fmt, ## __VA_ARGS__)
-#define DBGI(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)
+#define DBGE(part, fmt, ...)	DbgPrintEx(MY_DPFLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
+#define DBGW(part, fmt, ...)	DbgPrintEx(MY_DPFLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_WARNING_LEVEL, DRVPREFIX ":(WW) " fmt, ## __VA_ARGS__)
+#define DBGI(part, fmt, ...)	DbgPrintEx(MY_DPFLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)
 
 int dbg_snprintf(char *buf, int size, const char *fmt, ...);
 
@@ -26,5 +26,5 @@ const char *dbg_command(UINT32 command);
 
 #endif	
 
-#define ERROR(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
-#define INFO(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)
+#define ERROR(fmt, ...)	DbgPrintEx(MY_DPFLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
+#define INFO(fmt, ...)	DbgPrintEx(MY_DPFLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)

--- a/driver/lib/dbgcommon.h
+++ b/driver/lib/dbgcommon.h
@@ -9,9 +9,9 @@
 
 #include "usbip_proto.h"
 
-#define DBGE(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | (part), DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
-#define DBGW(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 1), DRVPREFIX ":(WW) " fmt, ## __VA_ARGS__)
-#define DBGI(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 2), DRVPREFIX ": " fmt, ## __VA_ARGS__)
+#define DBGE(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
+#define DBGW(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_WARNING_LEVEL, DRVPREFIX ":(WW) " fmt, ## __VA_ARGS__)
+#define DBGI(part, fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_MASK | ((part) << 4) | DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)
 
 int dbg_snprintf(char *buf, int size, const char *fmt, ...);
 
@@ -26,5 +26,5 @@ const char *dbg_command(UINT32 command);
 
 #endif	
 
-#define ERROR(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
-#define INFO(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)
+#define ERROR(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt "\n", ## __VA_ARGS__)
+#define INFO(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt "\n", ## __VA_ARGS__)

--- a/driver/lib/dbgcommon.h
+++ b/driver/lib/dbgcommon.h
@@ -26,5 +26,5 @@ const char *dbg_command(UINT32 command);
 
 #endif	
 
-#define ERROR(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt "\n", ## __VA_ARGS__)
-#define INFO(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt "\n", ## __VA_ARGS__)
+#define ERROR(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_ERROR_LEVEL, DRVPREFIX ":(EE) " fmt, ## __VA_ARGS__)
+#define INFO(fmt, ...)	DbgPrintEx(MY_DFPLTR, DPFLTR_INFO_LEVEL, DRVPREFIX ": " fmt, ## __VA_ARGS__)


### PR DESCRIPTION
During remote debugging I felt weird not seeing logs while having them enabled in registry.

DbgPrintEx usage has been corrected

when using values with a mask (0x8000000) log levels are explictly set at 4 bottom bits, and the rest part can be encoded in the following bits

reference:
https://docs.microsoft.com/pl-pl/windows-hardware/drivers/devtest/reading-and-filtering-debugging-messages