### PR TITLE
URB_FUNCTION_GET_STATUS_FROM_DEVICE implementation

### DIFF
--- a/driver/vhci/vhci_ioctl.c
+++ b/driver/vhci/vhci_ioctl.c
@@ -68,17 +68,6 @@ vhci_ioctl_abort_pipe(pusbip_vpdo_dev_t vpdo, USBD_PIPE_HANDLE hPipe)
 }
 
 static NTSTATUS
-process_urb_get_status(PURB urb)
-{
-	struct _URB_CONTROL_GET_STATUS_REQUEST	*urb_get = &urb->UrbControlGetStatusRequest;
-	if (urb_get->TransferBuffer != NULL && urb_get->TransferBufferLength == 2) {
-		*(USHORT *)urb_get->TransferBuffer = 0;
-		return STATUS_SUCCESS;
-	}
-	return STATUS_INVALID_PARAMETER;
-}
-
-static NTSTATUS
 process_urb_get_frame(pusbip_vpdo_dev_t vpdo, PURB urb)
 {
 	struct _URB_GET_CURRENT_FRAME_NUMBER	*urb_get = &urb->UrbGetCurrentFrameNumber;
@@ -114,15 +103,14 @@ process_irp_urb_req(pusbip_vpdo_dev_t vpdo, PIRP irp, PURB urb)
 	DBGI(DBG_IOCTL, "process_irp_urb_req: function: %s\n", dbg_urbfunc(urb->UrbHeader.Function));
 
 	switch (urb->UrbHeader.Function) {
-	case URB_FUNCTION_GET_STATUS_FROM_DEVICE:
-	case URB_FUNCTION_GET_STATUS_FROM_INTERFACE:
-	case URB_FUNCTION_GET_STATUS_FROM_ENDPOINT:
-	case URB_FUNCTION_GET_STATUS_FROM_OTHER:
-		return process_urb_get_status(urb);
 	case URB_FUNCTION_ABORT_PIPE:
 		return vhci_ioctl_abort_pipe(vpdo, urb->UrbPipeRequest.PipeHandle);
 	case URB_FUNCTION_GET_CURRENT_FRAME_NUMBER:
 		return process_urb_get_frame(vpdo, urb);
+	case URB_FUNCTION_GET_STATUS_FROM_DEVICE:
+	case URB_FUNCTION_GET_STATUS_FROM_INTERFACE:
+	case URB_FUNCTION_GET_STATUS_FROM_ENDPOINT:
+	case URB_FUNCTION_GET_STATUS_FROM_OTHER:
 	case URB_FUNCTION_SELECT_CONFIGURATION:
 	case URB_FUNCTION_ISOCH_TRANSFER:
 	case URB_FUNCTION_CLASS_DEVICE:

--- a/driver/vhci/vhci_write.c
+++ b/driver/vhci/vhci_write.c
@@ -214,6 +214,10 @@ store_urb_data(PURB urb, struct usbip_header *hdr)
 	switch (urb->UrbHeader.Function) {
 	case URB_FUNCTION_GET_DESCRIPTOR_FROM_INTERFACE:
 	case URB_FUNCTION_GET_DESCRIPTOR_FROM_DEVICE:
+	case URB_FUNCTION_GET_STATUS_FROM_DEVICE:
+	case URB_FUNCTION_GET_STATUS_FROM_INTERFACE:
+	case URB_FUNCTION_GET_STATUS_FROM_ENDPOINT:
+	case URB_FUNCTION_GET_STATUS_FROM_OTHER:
 		status = store_urb_control(urb, hdr);
 		break;
 	case URB_FUNCTION_CLASS_DEVICE:


### PR DESCRIPTION
Please check that the implementation of `store_urb_get_dev_status` makes sense, as the content of `wValue` may need to come from the `_URB_CONTROL_GET_STATUS_REQUEST` object.