### PR TITLE
fixed issue binding a USB serial device

### DIFF
--- a/userspace/lib/usbip_stub.c
+++ b/userspace/lib/usbip_stub.c
@@ -173,8 +173,8 @@ apply_stub_fdo(HDEVINFO dev_info, PSP_DEVINFO_DATA pdev_info_data)
 
 	/* update driver */
 	asprintf(&path_inf, "%s\\usbip_stub.inf", path_drvpkg);
-	if (!UpdateDriverForPlugAndPlayDevicesA(NULL, id_hw, path_inf, INSTALLFLAG_NONINTERACTIVE, &reboot_required)) {
-		err("failed to update driver: %lx", GetLastError());
+	if (!UpdateDriverForPlugAndPlayDevicesA(NULL, id_hw, path_inf, INSTALLFLAG_NONINTERACTIVE | INSTALLFLAG_FORCE, &reboot_required)) {
+		err("failed to update driver %s ; %s ; errorcode: %lx", path_inf, id_hw, GetLastError());
 		free(path_inf);
 		free(id_hw);
 		remove_dir_all(path_drvpkg);
@@ -218,7 +218,7 @@ attach_stub_driver(devno_t devno)
 {
 	int	ret;
 
-	ret = traverse_usbdevs(walker_attach, FALSE, &devno);
+	ret = traverse_usbdevs(walker_attach, TRUE, &devno);
 	if (ret == -1)
 		return TRUE;
 	return FALSE;
@@ -242,7 +242,7 @@ detach_stub_driver(devno_t devno)
 {
 	int	ret;
 
-	ret = traverse_usbdevs(walker_detach, FALSE, &devno);
+	ret = traverse_usbdevs(walker_detach, TRUE, &devno);
 	if (ret == 1)
 		return TRUE;
 	return FALSE;


### PR DESCRIPTION
Instead of attaching the selected device a different (not attached) device is selected.