### PR TITLE
driver: use ExAllocatePool2

### DIFF
--- a/driver/lib/strutil.c
+++ b/driver/lib/strutil.c
@@ -32,7 +32,7 @@ libdrv_strdupW(LPCWSTR cwstr)
 	status = RtlStringCchLengthW(cwstr, NTSTRSAFE_MAX_CCH, &len);
 	if (NT_ERROR(status))
 		return NULL;
-	wstr_duped = ExAllocatePoolWithTag(PagedPool, (len + 1) * sizeof(WCHAR), libdrv_pooltag);
+	wstr_duped = ExAllocatePool2(PagedPool, (len + 1) * sizeof(WCHAR), libdrv_pooltag);
 	if (wstr_duped == NULL)
 		return NULL;
 

--- a/driver/stub/stub_devconf.c
+++ b/driver/stub/stub_devconf.c
@@ -44,7 +44,7 @@ dup_info_intf(PUSBD_INTERFACE_INFORMATION info_intf)
 	PUSBD_INTERFACE_INFORMATION	info_intf_copied;
 	int	size_info = INFO_INTF_SIZE(info_intf);
 
-	info_intf_copied = ExAllocatePoolWithTag(NonPagedPool, size_info, USBIP_STUB_POOL_TAG);
+	info_intf_copied = ExAllocatePool2(NonPagedPool, size_info, USBIP_STUB_POOL_TAG);
 	if (info_intf_copied == NULL) {
 		DBGE(DBG_GENERAL, "dup_info_intf: out of memory\n");
 		return NULL;
@@ -76,13 +76,13 @@ create_devconf(PUSB_CONFIGURATION_DESCRIPTOR dsc_conf, USBD_CONFIGURATION_HANDLE
 	int	size_devconf;
 
 	size_devconf = sizeof(devconf_t) - sizeof(PUSBD_INTERFACE_INFORMATION) + dsc_conf->bNumInterfaces * sizeof(PUSBD_INTERFACE_INFORMATION);
-	devconf = (devconf_t *)ExAllocatePoolWithTag(NonPagedPool, size_devconf, USBIP_STUB_POOL_TAG);
+	devconf = (devconf_t *)ExAllocatePool2(NonPagedPool, size_devconf, USBIP_STUB_POOL_TAG);
 	if (devconf == NULL) {
 		DBGE(DBG_GENERAL, "create_devconf: out of memory\n");
 		return NULL;
 	}
 
-	devconf->dsc_conf = ExAllocatePoolWithTag(NonPagedPool, dsc_conf->wTotalLength, USBIP_STUB_POOL_TAG);
+	devconf->dsc_conf = ExAllocatePool2(NonPagedPool, dsc_conf->wTotalLength, USBIP_STUB_POOL_TAG);
 	if (devconf->dsc_conf == NULL) {
 		DBGE(DBG_GENERAL, "create_devconf: out of memory\n");
 		ExFreePoolWithTag(devconf, USBIP_STUB_POOL_TAG);

--- a/driver/stub/stub_reg.c
+++ b/driver/stub/stub_reg.c
@@ -21,7 +21,7 @@ reg_get_property(PDEVICE_OBJECT pdo, int property)
 		return NULL;
 	}
 
-	buf = ExAllocatePoolWithTag(PagedPool, len + sizeof(WCHAR), USBIP_STUB_POOL_TAG);
+	buf = ExAllocatePool2(PagedPool, len + sizeof(WCHAR), USBIP_STUB_POOL_TAG);
 	if (buf == NULL) {
 		DBGE(DBG_GENERAL, "reg_get_property: out of memory\n");
 		return NULL;
@@ -45,7 +45,7 @@ reg_get_property(PDEVICE_OBJECT pdo, int property)
 		return NULL;
 	}
 
-	prop = ExAllocatePoolWithTag(PagedPool, prop_ansi.Length + 1, USBIP_STUB_POOL_TAG);
+	prop = ExAllocatePool2(PagedPool, prop_ansi.Length + 1, USBIP_STUB_POOL_TAG);
 	if (prop == NULL) {
 		DBGE(DBG_GENERAL, "reg_get_property: out of memory\n");
 		RtlFreeAnsiString(&prop_ansi);

--- a/driver/stub/stub_res.c
+++ b/driver/stub/stub_res.c
@@ -40,7 +40,7 @@ create_stub_res(unsigned int cmd, unsigned long seqnum, int err, PVOID data, int
 {
 	stub_res_t	*sres;
 
-	sres = ExAllocatePoolWithTag(NonPagedPool, sizeof(stub_res_t), USBIP_STUB_POOL_TAG);
+	sres = ExAllocatePool2(NonPagedPool, sizeof(stub_res_t), USBIP_STUB_POOL_TAG);
 	if (sres == NULL) {
 		DBGE(DBG_GENERAL, "create_stub_res: out of memory\n");
 		if (data != NULL && !need_copy)
@@ -50,7 +50,7 @@ create_stub_res(unsigned int cmd, unsigned long seqnum, int err, PVOID data, int
 	if (data != NULL && need_copy) {
 		PVOID	data_copied;
 
-		data_copied = ExAllocatePoolWithTag(NonPagedPool, data_len, USBIP_STUB_POOL_TAG);
+		data_copied = ExAllocatePool2(NonPagedPool, data_len, USBIP_STUB_POOL_TAG);
 		if (data_copied == NULL) {
 			DBGE(DBG_GENERAL, "create_stub_res: out of memory. drop data.\n");
 			data_len = 0;

--- a/driver/stub/stub_usbd.c
+++ b/driver/stub/stub_usbd.c
@@ -68,7 +68,7 @@ call_usbd_nb(usbip_stub_dev_t *devstub, PURB purb, cb_urb_done_t cb_urb_done, st
 
 	DBGI(DBG_GENERAL, "call_usbd_nb: enter\n");
 
-	safe_completion = (safe_completion_t *)ExAllocatePoolWithTag(NonPagedPool, sizeof(safe_completion_t), USBIP_STUB_POOL_TAG);
+	safe_completion = (safe_completion_t *)ExAllocatePool2(NonPagedPool, sizeof(safe_completion_t), USBIP_STUB_POOL_TAG);
 	if (safe_completion == NULL) {
 		DBGE(DBG_GENERAL, "call_usbd_nb: out of memory: cannot allocate safe_completion\n");
 		return STATUS_NO_MEMORY;
@@ -221,7 +221,7 @@ get_usb_dsc_conf(usbip_stub_dev_t *devstub, UCHAR bVal)
 	if (iConfiguration == -1)
 		return NULL;
 
-	dsc_conf = ExAllocatePoolWithTag(NonPagedPool, ConfDesc.wTotalLength, USBIP_STUB_POOL_TAG);
+	dsc_conf = ExAllocatePool2(NonPagedPool, ConfDesc.wTotalLength, USBIP_STUB_POOL_TAG);
 	if (dsc_conf == NULL)
 		return NULL;
 
@@ -241,7 +241,7 @@ build_default_intf_list(PUSB_CONFIGURATION_DESCRIPTOR dsc_conf)
 	unsigned	i;
 
 	size = sizeof(USBD_INTERFACE_LIST_ENTRY) * (dsc_conf->bNumInterfaces + 1);
-	pintf_list = ExAllocatePoolWithTag(NonPagedPool, size, USBIP_STUB_POOL_TAG);
+	pintf_list = ExAllocatePool2(NonPagedPool, size, USBIP_STUB_POOL_TAG);
 	if (pintf_list == NULL)
 		return NULL;
 
@@ -335,7 +335,7 @@ select_usb_intf(usbip_stub_dev_t *devstub, UCHAR intf_num, USHORT alt_setting)
 	}
 
 	len_urb = sizeof(struct _URB_SELECT_INTERFACE) - sizeof(USBD_INTERFACE_INFORMATION) + info_intf_size;
-	purb = (PURB)ExAllocatePoolWithTag(NonPagedPool, len_urb, USBIP_STUB_POOL_TAG);
+	purb = (PURB)ExAllocatePool2(NonPagedPool, len_urb, USBIP_STUB_POOL_TAG);
 	if (purb == NULL) {
 		DBGE(DBG_GENERAL, "select_usb_intf: out of memory\n");
 		return FALSE;
@@ -449,7 +449,7 @@ submit_bulk_intr_transfer(usbip_stub_dev_t *devstub, USBD_PIPE_HANDLE hPipe, uns
 	ULONG		flags = USBD_SHORT_TRANSFER_OK;
 	stub_res_t	*sres;
 
-	purb = ExAllocatePoolWithTag(NonPagedPool, sizeof(struct _URB_BULK_OR_INTERRUPT_TRANSFER), USBIP_STUB_POOL_TAG);
+	purb = ExAllocatePool2(NonPagedPool, sizeof(struct _URB_BULK_OR_INTERRUPT_TRANSFER), USBIP_STUB_POOL_TAG);
 	if (purb == NULL) {
 		DBGE(DBG_GENERAL, "submit_bulk_intr_transfer: out of memory: urb\n");
 		return STATUS_NO_MEMORY;
@@ -513,7 +513,7 @@ done_iso_transfer(usbip_stub_dev_t *devstub, NTSTATUS status, PURB purb, stub_re
 				}
 			}
 			else {
-				sres->data = ExAllocatePoolWithTag(NonPagedPool, (SIZE_T)sres->data_len, USBIP_STUB_POOL_TAG);
+				sres->data = ExAllocatePool2(NonPagedPool, (SIZE_T)sres->data_len, USBIP_STUB_POOL_TAG);
 				if (sres->data == NULL) {
 					DBGE(DBG_GENERAL, "done_iso_transfer: out of memory\n");
 					sres->data_len = 0;

--- a/driver/stub/stub_write.c
+++ b/driver/stub/stub_write.c
@@ -69,7 +69,7 @@ process_get_desc(usbip_stub_dev_t *devstub, unsigned int seqnum, usb_cspkt_t *cs
 
 	DBGI(DBG_READWRITE, "get_desc: %s\n", dbg_cspkt_desctype(CSPKT_DESCRIPTOR_TYPE(csp)));
 
-	pdesc = ExAllocatePoolWithTag(NonPagedPool, csp->wLength, USBIP_STUB_POOL_TAG);
+	pdesc = ExAllocatePool2(NonPagedPool, csp->wLength, USBIP_STUB_POOL_TAG);
 	if (pdesc == NULL) {
 		DBGE(DBG_READWRITE, "process_get_desc: out of memory\n");
 		reply_stub_req_err(devstub, USBIP_RET_SUBMIT, seqnum, -1);
@@ -224,7 +224,7 @@ process_class_vendor_request(usbip_stub_dev_t *devstub, usb_cspkt_t *csp, struct
 		data = NULL;
 	else {
 		if (is_in) {
-			data = ExAllocatePoolWithTag(NonPagedPool, (SIZE_T)datalen, USBIP_STUB_POOL_TAG);
+			data = ExAllocatePool2(NonPagedPool, (SIZE_T)datalen, USBIP_STUB_POOL_TAG);
 			if (data == NULL) {
 				DBGE(DBG_GENERAL, "process_class_vendor_request: out of memory\n");
 				reply_stub_req_err(devstub, USBIP_RET_SUBMIT, hdr->base.seqnum, -1);
@@ -310,7 +310,7 @@ process_bulk_intr_transfer(usbip_stub_dev_t *devstub, PUSBD_PIPE_INFORMATION inf
 	datalen = (ULONG)hdr->u.cmd_submit.transfer_buffer_length;
 	is_in = hdr->base.direction ? TRUE : FALSE;
 	if (is_in) {
-		data = ExAllocatePoolWithTag(NonPagedPool, (SIZE_T)datalen, USBIP_STUB_POOL_TAG);
+		data = ExAllocatePool2(NonPagedPool, (SIZE_T)datalen, USBIP_STUB_POOL_TAG);
 		if (data == NULL) {
 			DBGE(DBG_GENERAL, "process_bulk_intr_transfer: out of memory\n");
 			reply_stub_req_err(devstub, USBIP_RET_SUBMIT, hdr->base.seqnum, -1);
@@ -352,7 +352,7 @@ process_iso_transfer(usbip_stub_dev_t *devstub, PUSBD_PIPE_INFORMATION info_pipe
 	if (is_in) {
 		iso_descs = (struct usbip_iso_packet_descriptor *)(hdr + 1);
 		datalen = get_iso_descs_len(n_pkts, iso_descs, FALSE);
-		data = ExAllocatePoolWithTag(NonPagedPool, (SIZE_T)datalen + sizeof(struct usbip_iso_packet_descriptor) * n_pkts, USBIP_STUB_POOL_TAG);
+		data = ExAllocatePool2(NonPagedPool, (SIZE_T)datalen + sizeof(struct usbip_iso_packet_descriptor) * n_pkts, USBIP_STUB_POOL_TAG);
 		if (data == NULL) {
 			DBGE(DBG_GENERAL, "process_iso_transfer: out of memory\n");
 			reply_stub_req_err(devstub, USBIP_RET_SUBMIT, hdr->base.seqnum, -1);
@@ -364,7 +364,7 @@ process_iso_transfer(usbip_stub_dev_t *devstub, PUSBD_PIPE_INFORMATION info_pipe
 		/* Allocate more space for iso descriptors which will maintain length field */
 		datalen = (ULONG)hdr->u.cmd_submit.transfer_buffer_length;
 		iso_descs = (struct usbip_iso_packet_descriptor *)((char *)(hdr + 1) + datalen);
-		data = ExAllocatePoolWithTag(NonPagedPool, (SIZE_T)(datalen + iso_descs_len), USBIP_STUB_POOL_TAG);
+		data = ExAllocatePool2(NonPagedPool, (SIZE_T)(datalen + iso_descs_len), USBIP_STUB_POOL_TAG);
 		if (data == NULL) {
 			DBGE(DBG_GENERAL, "process_iso_transfer: out of memory\n");
 			reply_stub_req_err(devstub, USBIP_RET_SUBMIT, hdr->base.seqnum, -1);

--- a/driver/vhci/vhci.c
+++ b/driver/vhci/vhci.c
@@ -165,7 +165,7 @@ DriverEntry(__in PDRIVER_OBJECT drvobj, __in PUNICODE_STRING RegistryPath)
 	// Save the RegistryPath for WMI.
 	Globals.RegistryPath.MaximumLength = RegistryPath->Length + sizeof(UNICODE_NULL);
 	Globals.RegistryPath.Length = RegistryPath->Length;
-	Globals.RegistryPath.Buffer = ExAllocatePoolWithTag(PagedPool, Globals.RegistryPath.MaximumLength, USBIP_VHCI_POOL_TAG);
+	Globals.RegistryPath.Buffer = ExAllocatePool2(PagedPool, Globals.RegistryPath.MaximumLength, USBIP_VHCI_POOL_TAG);
 
 	if (!Globals.RegistryPath.Buffer) {
 		ExDeleteNPagedLookasideList(&g_lookaside);

--- a/driver/vhci/vhci_dev.c
+++ b/driver/vhci/vhci_dev.c
@@ -32,7 +32,7 @@ get_device_prop(PDEVICE_OBJECT pdo, DEVICE_REGISTRY_PROPERTY prop, PULONG plen)
 		DBGE(DBG_GENERAL, "failed to get device property size: %s\n", dbg_ntstatus(status));
 		return NULL;
 	}
-	value = ExAllocatePoolWithTag(PagedPool, buflen, USBIP_VHCI_POOL_TAG);
+	value = ExAllocatePool2(PagedPool, buflen, USBIP_VHCI_POOL_TAG);
 	if (value == NULL) {
 		DBGE(DBG_GENERAL, "failed to get device property: out of memory\n");
 		return NULL;

--- a/driver/vhci/vhci_pnp.c
+++ b/driver/vhci/vhci_pnp.c
@@ -111,7 +111,7 @@ pnp_query_bus_information(PIRP irp)
 
 	PAGED_CODE();
 
-	busInfo = ExAllocatePoolWithTag(PagedPool, sizeof(PNP_BUS_INFORMATION), USBIP_VHCI_POOL_TAG);
+	busInfo = ExAllocatePool2(PagedPool, sizeof(PNP_BUS_INFORMATION), USBIP_VHCI_POOL_TAG);
 
 	if (busInfo == NULL) {
 		return STATUS_INSUFFICIENT_RESOURCES;

--- a/driver/vhci/vhci_pnp_id.c
+++ b/driver/vhci/vhci_pnp_id.c
@@ -66,7 +66,7 @@ setup_device_id(pvdev_t vdev, PIRP irp)
 	}
 
 	id_size = vdev_devid_size[vdev->type];
-	id_dev = ExAllocatePoolWithTag(PagedPool, id_size, USBIP_VHCI_POOL_TAG);
+	id_dev = ExAllocatePool2(PagedPool, id_size, USBIP_VHCI_POOL_TAG);
 	if (id_dev == NULL) {
 		DBGE(DBG_PNP, "%s: query device id: out of memory\n", dbg_vdev_type(vdev->type));
 		return STATUS_INSUFFICIENT_RESOURCES;
@@ -99,7 +99,7 @@ setup_hw_ids(pvdev_t vdev, PIRP irp)
 	}
 
 	ids_size = vdev_hwids_size[vdev->type];
-	ids_hw = ExAllocatePoolWithTag(PagedPool, ids_size, USBIP_VHCI_POOL_TAG);
+	ids_hw = ExAllocatePool2(PagedPool, ids_size, USBIP_VHCI_POOL_TAG);
 	if (ids_hw == NULL) {
 		DBGE(DBG_PNP, "%s: query hw ids: out of memory\n", dbg_vdev_type(vdev->type));
 		return STATUS_INSUFFICIENT_RESOURCES;
@@ -141,7 +141,7 @@ setup_inst_id_or_serial(pvdev_t vdev, PIRP irp, BOOLEAN serial)
 
 	vpdo = (pvpdo_dev_t)vdev;
 
-	id_inst = ExAllocatePoolWithTag(PagedPool, (MAX_VHCI_SERIAL_ID + 1) * sizeof(wchar_t), USBIP_VHCI_POOL_TAG);
+	id_inst = ExAllocatePool2(PagedPool, (MAX_VHCI_SERIAL_ID + 1) * sizeof(wchar_t), USBIP_VHCI_POOL_TAG);
 	if (id_inst == NULL) {
 		DBGE(DBG_PNP, "vpdo: query instance id or serial: out of memory\n");
 		return STATUS_INSUFFICIENT_RESOURCES;
@@ -195,7 +195,7 @@ setup_compat_ids(pvdev_t vdev, PIRP irp)
 
 	vpdo = (pvpdo_dev_t)vdev;
 
-	ids_compat = ExAllocatePoolWithTag(PagedPool, ids_size, USBIP_VHCI_POOL_TAG);
+	ids_compat = ExAllocatePool2(PagedPool, ids_size, USBIP_VHCI_POOL_TAG);
 	if (ids_compat == NULL) {
 		DBGE(DBG_PNP, "vpdo: query compatible id: out of memory\n");
 		return STATUS_INSUFFICIENT_RESOURCES;

--- a/driver/vhci/vhci_pnp_relations.c
+++ b/driver/vhci/vhci_pnp_relations.c
@@ -38,7 +38,7 @@ get_bus_relations_1_child(pvdev_t vdev, PDEVICE_RELATIONS *pdev_relations)
 		child_exist = FALSE;
 
 	if (relations == NULL) {
-		relations = (PDEVICE_RELATIONS)ExAllocatePoolWithTag(PagedPool, sizeof(DEVICE_RELATIONS), USBIP_VHCI_POOL_TAG);
+		relations = (PDEVICE_RELATIONS)ExAllocatePool2(PagedPool, sizeof(DEVICE_RELATIONS), USBIP_VHCI_POOL_TAG);
 		if (relations == NULL) {
 			DBGE(DBG_PNP, "no relations will be reported: out of memory\n");
 			return STATUS_INSUFFICIENT_RESOURCES;
@@ -65,7 +65,7 @@ get_bus_relations_1_child(pvdev_t vdev, PDEVICE_RELATIONS *pdev_relations)
 
 	// Need to allocate a new relations structure and add vhub to it
 	size = sizeof(DEVICE_RELATIONS) + relations->Count * sizeof(PDEVICE_OBJECT);
-	relations_new = (PDEVICE_RELATIONS)ExAllocatePoolWithTag(PagedPool, size, USBIP_VHCI_POOL_TAG);
+	relations_new = (PDEVICE_RELATIONS)ExAllocatePool2(PagedPool, size, USBIP_VHCI_POOL_TAG);
 	if (relations_new == NULL) {
 		DBGE(DBG_VHUB, "old relations will be used: out of memory\n");
 		return STATUS_INSUFFICIENT_RESOURCES;
@@ -124,7 +124,7 @@ get_bus_relations_vhub(pvhub_dev_t vhub, PDEVICE_RELATIONS *pdev_relations)
 	// Need to allocate a new relations structure and add our vpdos to it
 	length = sizeof(DEVICE_RELATIONS) + (vhub->n_vpdos_plugged + n_olds - 1) * sizeof(PDEVICE_OBJECT);
 
-	relations = (PDEVICE_RELATIONS)ExAllocatePoolWithTag(PagedPool, length, USBIP_VHCI_POOL_TAG);
+	relations = (PDEVICE_RELATIONS)ExAllocatePool2(PagedPool, length, USBIP_VHCI_POOL_TAG);
 	if (relations == NULL) {
 		DBGE(DBG_VHUB, "failed to allocate a new relation: out of memory\n");
 
@@ -175,7 +175,7 @@ get_self_dev_relation(pvdev_t vdev)
 {
 	PDEVICE_RELATIONS	dev_relations;
 
-	dev_relations = (PDEVICE_RELATIONS)ExAllocatePoolWithTag(PagedPool, sizeof(DEVICE_RELATIONS), USBIP_VHCI_POOL_TAG);
+	dev_relations = (PDEVICE_RELATIONS)ExAllocatePool2(PagedPool, sizeof(DEVICE_RELATIONS), USBIP_VHCI_POOL_TAG);
 	if (dev_relations == NULL)
 		return NULL;
 

--- a/driver/vhci/vhci_pnp_resources.c
+++ b/driver/vhci/vhci_pnp_resources.c
@@ -8,7 +8,7 @@ get_query_empty_resource_requirements(void)
 {
 	PIO_RESOURCE_REQUIREMENTS_LIST	reqs;
 
-	reqs = ExAllocatePoolWithTag(PagedPool, sizeof(IO_RESOURCE_REQUIREMENTS_LIST), USBIP_VHCI_POOL_TAG);
+	reqs = ExAllocatePool2(PagedPool, sizeof(IO_RESOURCE_REQUIREMENTS_LIST), USBIP_VHCI_POOL_TAG);
 	if (reqs == NULL) {
 		return NULL;
 	}
@@ -27,7 +27,7 @@ get_query_empty_resources(void)
 {
 	PCM_RESOURCE_LIST	rscs;
 
-	rscs = ExAllocatePoolWithTag(PagedPool, sizeof(CM_RESOURCE_LIST), USBIP_VHCI_POOL_TAG);
+	rscs = ExAllocatePool2(PagedPool, sizeof(CM_RESOURCE_LIST), USBIP_VHCI_POOL_TAG);
 	if (rscs == NULL) {
 		return NULL;
 	}

--- a/driver/vhci/vhci_vpdo.c
+++ b/driver/vhci/vhci_vpdo.c
@@ -21,7 +21,7 @@ vpdo_select_config(pvpdo_dev_t vpdo, struct _URB_SELECT_CONFIGURATION *urb_selc)
 	}
 
 	if (vpdo->dsc_conf == NULL || vpdo->dsc_conf->wTotalLength != dsc_conf->wTotalLength) {
-		dsc_conf_new = ExAllocatePoolWithTag(NonPagedPool, dsc_conf->wTotalLength, USBIP_VHCI_POOL_TAG);
+		dsc_conf_new = ExAllocatePool2(NonPagedPool, dsc_conf->wTotalLength, USBIP_VHCI_POOL_TAG);
 		if (dsc_conf_new == NULL) {
 			DBGE(DBG_WRITE, "failed to allocate configuration descriptor: out of memory\n");
 			return STATUS_UNSUCCESSFUL;

--- a/driver/vhci/vhci_vpdo_dsc.c
+++ b/driver/vhci/vhci_vpdo_dsc.c
@@ -115,7 +115,7 @@ try_to_cache_descriptor(pvpdo_dev_t vpdo, struct _URB_CONTROL_DESCRIPTOR_REQUEST
 	if (!need_caching_dsc(vpdo, urb_cdr, dsc))
 		return;
 
-	dsc_new = ExAllocatePoolWithTag(PagedPool, urb_cdr->TransferBufferLength, USBIP_VHCI_POOL_TAG);
+	dsc_new = ExAllocatePool2(PagedPool, urb_cdr->TransferBufferLength, USBIP_VHCI_POOL_TAG);
 	if (dsc_new == NULL) {
 		DBGE(DBG_WRITE, "out of memory\n");
 		return;

--- a/driver/vhci_ude/vhci_hc.c
+++ b/driver/vhci_ude/vhci_hc.c
@@ -112,7 +112,7 @@ setup_vhci(pctx_vhci_t vhci)
 	vhci->n_max_ports = MAX_HUB_30PORTS + MAX_HUB_20PORTS;
 	vhci->n_used_ports = 0;
 
-	vhci->vusbs = ExAllocatePoolWithTag(NonPagedPool, sizeof(pctx_vusb_t) * vhci->n_max_ports, VHCI_POOLTAG);
+	vhci->vusbs = ExAllocatePool2(NonPagedPool, sizeof(pctx_vusb_t) * vhci->n_max_ports, VHCI_POOLTAG);
 	if (vhci->vusbs == NULL) {
 		TRE(VHCI, "failed to allocate ports: out of memory");
 		return FALSE;

--- a/driver/vhci_ude/vhci_plugin.c
+++ b/driver/vhci_ude/vhci_plugin.c
@@ -33,7 +33,7 @@ setup_with_dsc_dev(pctx_vusb_t vusb, PUSB_DEVICE_DESCRIPTOR dsc_dev)
 static BOOLEAN
 setup_with_dsc_conf(pctx_vusb_t vusb, PUSB_CONFIGURATION_DESCRIPTOR dsc_conf)
 {
-	vusb->dsc_conf = ExAllocatePoolWithTag(PagedPool, dsc_conf->wTotalLength, VHCI_POOLTAG);
+	vusb->dsc_conf = ExAllocatePool2(PagedPool, dsc_conf->wTotalLength, VHCI_POOLTAG);
 	if (vusb->dsc_conf == NULL) {
 		TRE(PLUGIN, "failed to allocate configuration descriptor");
 		return FALSE;
@@ -43,7 +43,7 @@ setup_with_dsc_conf(pctx_vusb_t vusb, PUSB_CONFIGURATION_DESCRIPTOR dsc_conf)
 	if (dsc_conf->bNumInterfaces > 0) {
 		int	i;
 
-		vusb->intf_altsettings = (PSHORT)ExAllocatePoolWithTag(PagedPool, dsc_conf->bNumInterfaces * sizeof(SHORT), VHCI_POOLTAG);
+		vusb->intf_altsettings = (PSHORT)ExAllocatePool2(PagedPool, dsc_conf->bNumInterfaces * sizeof(SHORT), VHCI_POOLTAG);
 		if (vusb->intf_altsettings == NULL) {
 			TRE(PLUGIN, "failed to allocate alternative settings for interfaces");
 			return FALSE;

--- a/driver/vhci_ude/vhci_urbr_store_control.c
+++ b/driver/vhci_ude/vhci_urbr_store_control.c
@@ -110,7 +110,7 @@ fetch_done_urbr_control_transfer_ex(pctx_vusb_t vusb, struct _URB_CONTROL_TRANSF
 	NTSTATUS	status;
 
 	len = libdrv_strlenW(vusb->wserial) * sizeof(WCHAR) + 2;
-	dsc_serial = ExAllocatePoolWithTag(PagedPool, len, VHCI_POOLTAG);
+	dsc_serial = ExAllocatePool2(PagedPool, len, VHCI_POOLTAG);
 	*(PUCHAR)dsc_serial = (UCHAR)len;
 	((PUCHAR)dsc_serial)[1] = 0x03;
 	RtlCopyMemory((PUCHAR)dsc_serial + 2, vusb->wserial, len - 2);


### PR DESCRIPTION
ExAllocatePoolWithTag is deprecated as of Win10 20.04
This adds compat for newer WDK releases
I'll admit this was a oneshot PR, so def needs review, but this should mostly be a drop-in replacement (https://learn.microsoft.com/en-us/windows-hardware/drivers/kernel/updating-deprecated-exallocatepool-calls)