### PR TITLE
Add note that this repo has been de facto superceded by usbip-win2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# usbip-win2
+
+This repo has been de facto superseded by [usbip-win2](https://github.com/vadimgrn/usbip-win2).
+
 # USB/IP for Windows
 
 - This project aims to support both a USB/IP server and a client on Windows platform.


### PR DESCRIPTION
It doesn't seem like this repo is being maintained anymore. After spending some time patching it and coercing it to build, I learned that it has been de facto superseded by [usbip-win2](https://github.com/vadimgrn/usbip-win2). This PR adds a note at the top of this repo's README directing users to usbip-win2.